### PR TITLE
Bordered window

### DIFF
--- a/src/renderer/assets/css/_base.sass
+++ b/src/renderer/assets/css/_base.sass
@@ -10,6 +10,8 @@ body
 	font-weight: 400
 	color: #222831
 	overflow: hidden
+	border: 1px solid #DEE0E3
+	max-height: 100vh
 
 a
 	cursor: pointer


### PR DESCRIPTION
Add a light color border around the `body` tag.

![image](https://user-images.githubusercontent.com/29014463/57431224-bff50700-724f-11e9-80f6-21b9fe00a4d2.png)

Closes #48
