### PR TITLE
Fix: package.json not found in information page

### DIFF
--- a/src/renderer/pages/settings/information.vue
+++ b/src/renderer/pages/settings/information.vue
@@ -55,11 +55,6 @@ export default {
 				}
 			}
 		};
-	},
-	computed: {
-		packageVersion() {
-			return process.env.npm_package_version;
-		}
 	}
 };
 </script>

--- a/src/renderer/pages/settings/information.vue
+++ b/src/renderer/pages/settings/information.vue
@@ -20,7 +20,7 @@
 </template>
 
 <script>
-import packageJson from "../../../package.json";
+import packageJson from "../../../../package.json";
 
 export default {
 	data() {


### PR DESCRIPTION
Azure pipeline shows the error build fails, as it is not able to find the `package.json` module in `settings/information.vue` page.

https://dev.azure.com/codecarrot/Thermal/_build/results?buildId=1024&view=logs