### PR TITLE
Settings to auto initialize non-git repository

### DIFF
--- a/src/renderer/App.vue
+++ b/src/renderer/App.vue
@@ -113,7 +113,11 @@ export default {
 		}
 	},
 	beforeCreate() {
-		this.$store.commit("settings/getSettingsList");
+		if (localStorage.getItem("settings")) {
+			this.$store.commit("settings/getSettingsList");
+		} else {
+			this.$store.commit("settings/setSettings");
+		}
 	},
 	mounted() {
 		this.queryAllRepository();

--- a/src/renderer/pages/settings/experimental.vue
+++ b/src/renderer/pages/settings/experimental.vue
@@ -13,6 +13,23 @@
 				class="settings__section__group__item"
 			>
 				<div>
+					<h6>Auto init</h6>
+					<p>
+						Automatically initalize a non-git repository.
+					</p>
+				</div>
+				<toggle-button
+					v-model="toggleAutoInit"
+					color="#00adb5"
+					class="ml-auto"
+				/>
+			</t-flexbox>
+			<t-flexbox
+				flex-direction="row"
+				align-items="center"
+				class="settings__section__group__item"
+			>
+				<div>
 					<h6>File changes</h6>
 					<p>
 						Preview additions and deletion in file from commit history,
@@ -58,6 +75,17 @@ export default {
 		ToggleButton
 	},
 	computed: {
+		toggleAutoInit: {
+			get: function() {
+				return this.$store.state.settings.experimental.autoInit;
+			},
+			set: function(value) {
+				this.$store.dispatch({
+					type: "settings/updateAutoInit",
+					autoInit: value
+				});
+			}
+		},
 		toggleFileChanges: {
 			get: function() {
 				return this.$store.state.settings.experimental.fileChanges;

--- a/src/renderer/pages/settings/experimental.vue
+++ b/src/renderer/pages/settings/experimental.vue
@@ -80,10 +80,7 @@ export default {
 				return this.$store.state.settings.experimental.autoInit;
 			},
 			set: function(value) {
-				this.$store.dispatch({
-					type: "settings/updateAutoInit",
-					autoInit: value
-				});
+				this.$store.dispatch("settings/updateAutoInit", value);
 			}
 		},
 		toggleFileChanges: {
@@ -91,10 +88,7 @@ export default {
 				return this.$store.state.settings.experimental.fileChanges;
 			},
 			set: function(value) {
-				this.$store.dispatch({
-					type: "settings/updateFileChanges",
-					fileChanges: value
-				});
+				this.$store.dispatch("settings/updateFileChanges", value);
 			}
 		},
 		toggleQuickFilePreview: {
@@ -102,10 +96,7 @@ export default {
 				return this.$store.state.settings.experimental.quickFilePreview;
 			},
 			set: function(value) {
-				this.$store.dispatch({
-					type: "settings/updateQuickFilePreview",
-					quickFilePreview: value
-				});
+				this.$store.dispatch("settings/updateQuickFilePreview", value);
 			}
 		}
 	},

--- a/src/renderer/pages/settings/experimental.vue
+++ b/src/renderer/pages/settings/experimental.vue
@@ -15,7 +15,7 @@
 				<div>
 					<h6>Auto init</h6>
 					<p>
-						Automatically initalize a non-git repository.
+						Automatically initialize a non-git repository.
 					</p>
 				</div>
 				<toggle-button

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -26,7 +26,9 @@ const mutations = {
 		).experimental;
 	},
 	setSettings(state) {
+		console.log('Running set settings.')
 		localStorage.setItem("settings", JSON.stringify(state));
+		console.log(state)
 	},
 	authorName(state, payload) {
 		state.profile.author.name = payload.name;
@@ -79,7 +81,7 @@ const actions = {
 	updateAutoInit: ({ commit }, payload) => {
 		commit({
 			type: "toggleAutoInit",
-			fileChanges: payload
+			autoInit: payload
 		});
 		commit({
 			type: "setSettings"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -19,12 +19,10 @@ const getters = {
 
 const mutations = {
 	getSettingsList(state) {
-		if (localStorage.getItem("settings")) {
-			state.profile = JSON.parse(localStorage.getItem("settings")).profile;
-			state.experimental = JSON.parse(
-				localStorage.getItem("settings")
-			).experimental;
-		}
+		state.profile = JSON.parse(localStorage.getItem("settings")).profile;
+		state.experimental = JSON.parse(
+			localStorage.getItem("settings")
+		).experimental;
 	},
 	setSettings(state) {
 		localStorage.setItem("settings", JSON.stringify(state));

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -7,6 +7,7 @@ const state = {
 		}
 	},
 	experimental: {
+		autoInit: false,
 		fileChanges: true,
 		quickFilePreview: false
 	}
@@ -35,6 +36,9 @@ const mutations = {
 	},
 	authorImage(state, payload) {
 		state.profile.author.imageUrl = payload.image;
+	},
+	toggleAutoInit(state, payload) {
+		state.experimental.autoInit = payload.autoInit;
 	},
 	toggleFileChanges(state, payload) {
 		state.experimental.fileChanges = payload.fileChanges;
@@ -67,6 +71,15 @@ const actions = {
 		commit({
 			type: "authorImage",
 			image: payload.image
+		});
+		commit({
+			type: "setSettings"
+		});
+	},
+	updateAutoInit: ({ commit }, payload) => {
+		commit({
+			type: "toggleAutoInit",
+			fileChanges: payload.autoInit
 		});
 		commit({
 			type: "setSettings"

--- a/src/renderer/store/modules/settings.js
+++ b/src/renderer/store/modules/settings.js
@@ -79,7 +79,7 @@ const actions = {
 	updateAutoInit: ({ commit }, payload) => {
 		commit({
 			type: "toggleAutoInit",
-			fileChanges: payload.autoInit
+			fileChanges: payload
 		});
 		commit({
 			type: "setSettings"
@@ -88,7 +88,7 @@ const actions = {
 	updateFileChanges: ({ commit }, payload) => {
 		commit({
 			type: "toggleFileChanges",
-			fileChanges: payload.fileChanges
+			fileChanges: payload
 		});
 		commit({
 			type: "setSettings"
@@ -97,7 +97,7 @@ const actions = {
 	updateQuickFilePreview: ({ commit }, payload) => {
 		commit({
 			type: "toggleQuickFilePreview",
-			quickFilePreview: payload.quickFilePreview
+			quickFilePreview: payload
 		});
 		commit({
 			type: "setSettings"


### PR DESCRIPTION
This PR added the option in the Settings page of the app allowing users to toggle (`on`/`off`) this feature.

This feature automatically initializes git inside a non-git repository.