### PR TITLE
[macOS] Electron native menubar

### DIFF
--- a/src/main/config.js
+++ b/src/main/config.js
@@ -1,0 +1,23 @@
+const { app } = require("electron");
+
+/**
+ * Applications Configuration
+ **/
+module.exports = {
+	APP_NAME: "Thermal",
+	APP_VERSION: app.getVersion(),
+
+	THERMAL_URL_WEBSITE: "https://thermal.codecarrot.net/",
+	GITHUB_URL: "https://www.github.com/gitthermal/thermal",
+	GITHUB_URL_LICENSE:
+		"https://github.com/gitthermal/thermal/blob/master/LICENCE",
+	GITHUB_URL_ISSUES:
+		"https://github.com/gitthermal/thermal/issues/new?assignees=&labels=🐞+Bug&template=bug_report.md",
+	GITHUB_URL_RELEASE_NOTES: "https://github.com/gitthermal/thermal/releases",
+	DISCORD_INVITE_URL: "https://discord.gg/DcSNmts",
+
+	WINDOW_DEFAULT_HEIGHT: 800,
+	WINDOW_DEFAULT_WIDTH: 1200,
+
+	ICON: "../../build/icons/256x256.png"
+};

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -36,7 +36,6 @@ function createWindow() {
 		height: CONFIG.WINDOW_DEFAULT_HEIGHT,
 		width: CONFIG.WINDOW_DEFAULT_WIDTH,
 		webPreferences: {
-			devTools: true,
 			nodeIntegration: true
 		}
 	});

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4,6 +4,8 @@ import { app, BrowserWindow } from "electron";
 import * as Sentry from "@sentry/electron";
 import packageJson from "../../package.json";
 
+const CONFIG = require("./config");
+
 Sentry.init({
 	dsn: "https://c3fb5f4c94aa4921a71b5fb887e1cfac@sentry.io/1422446",
 	environment: process.env.NODE_ENV,
@@ -31,10 +33,8 @@ function createWindow() {
 	 * Initial window options
 	 */
 	mainWindow = new BrowserWindow({
-		height: 563,
-		useContentSize: true,
-		width: 1000,
-		frame: false,
+		height: CONFIG.WINDOW_DEFAULT_HEIGHT,
+		width: CONFIG.WINDOW_DEFAULT_WIDTH,
 		webPreferences: {
 			devTools: true,
 			nodeIntegration: true

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -4,6 +4,7 @@ import { app, BrowserWindow } from "electron";
 import * as Sentry from "@sentry/electron";
 import packageJson from "../../package.json";
 
+const buildMenu = require("./menu");
 const CONFIG = require("./config");
 
 Sentry.init({
@@ -35,6 +36,8 @@ function createWindow() {
 	mainWindow = new BrowserWindow({
 		height: CONFIG.WINDOW_DEFAULT_HEIGHT,
 		width: CONFIG.WINDOW_DEFAULT_WIDTH,
+		titleBarStyle: "hidden",
+
 		webPreferences: {
 			nodeIntegration: true
 		}
@@ -48,10 +51,15 @@ function createWindow() {
 }
 
 app.on("ready", () => {
+	if (process.platform === "darwin") {
+		buildMenu();
+	}
 	createWindow();
 });
 
 app.on("window-all-closed", () => {
+	// On OS X it is common for applications and their menu bar
+	// to stay active until the user quits explicitly with Cmd + Q
 	if (process.platform !== "darwin") {
 		app.quit();
 	}

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -1,0 +1,188 @@
+const { Menu, shell, dialog } = require("electron");
+const CONFIG = require("./config");
+
+/**
+ * Menu template
+ */
+
+const template = [
+	{
+		label: CONFIG.APP_NAME,
+		submenu: [
+			{
+				label: `About ${CONFIG.APP_NAME}`,
+				click() {
+					showAboutDialog();
+				}
+			},
+			{
+				label: "Preferences",
+				click() {
+					console.log("Open preferences page.");
+				}
+			},
+			{ type: "separator" },
+			{
+				label: "Release notes",
+				click() {
+					shell.openExternal(CONFIG.GITHUB_URL_RELEASE_NOTES);
+				}
+			},
+			{
+				label: "License",
+				click() {
+					shell.openExternal(CONFIG.GITHUB_URL_LICENSE);
+				}
+			},
+			{ type: "separator" },
+			{
+				label: "Check for updates...",
+				click() {
+					showUpdatesDialog();
+				}
+			},
+			{ type: "separator" },
+			{ role: "hide" },
+			{ role: "hideOthers" },
+			{ role: "unhide" },
+			{ type: "separator" },
+			{ role: "quit" }
+		]
+	},
+	{
+		label: "File",
+		submenu: [
+			{
+				label: "Select repository"
+			},
+			{ type: "separator" },
+			{
+				label: "New repository"
+			},
+			{ type: "separator" },
+			{
+				label: "Add local repository"
+			},
+			{
+				label: "Clone repository"
+			}
+		]
+	},
+	{
+		label: "View",
+		submenu: [
+			{
+				label: "Toggle Full Screen",
+				accelerator: (() => {
+					if (process.platform === "darwin") {
+						return "Ctrl+Command+F";
+					} else {
+						return "F11";
+					}
+				})(),
+				click: function (focusedWindow) {
+					if (focusedWindow) {
+						focusedWindow.setFullScreen(!focusedWindow.isFullScreen());
+					}
+				}
+			},
+			{
+				label: "Toggle Developer Tools",
+				accelerator: (function () {
+					if (process.platform === "darwin") {
+						return "Alt+Command+I";
+					} else {
+						return "Ctrl+Shift+I";
+					}
+				})(),
+				click: function (item, focusedWindow) {
+					if (focusedWindow) {
+						focusedWindow.toggleDevTools();
+					}
+				}
+			}
+		]
+	},
+	{
+		label: "Window",
+		role: "window",
+		submenu: [
+			{
+				label: "Minimize",
+				accelerator: "CmdOrCtrl+M",
+				role: "minimize"
+			},
+			{
+				label: "Reload",
+				accelerator: "CmdOrCtrl+R",
+				role: "reload"
+			},
+			{
+				label: "Force Reload",
+				accelerator: "CmdOrCtrl+Shift+R",
+				role: "forceReload"
+			},
+			{
+				label: "Close",
+				accelerator: "CmdOrCtrl+W",
+				role: "close"
+			}
+		]
+	},
+	{
+		label: "Help",
+		submenu: [
+			{
+				label: "Learn more",
+				click() {
+					shell.openExternal(CONFIG.THERMAL_URL_WEBSITE);
+				}
+			},
+			{ type: "separator" },
+			{
+				label: "Report an issue",
+				click() {
+					shell.openExternal(CONFIG.GITHUB_URL_ISSUES);
+				}
+			},
+			{
+				label: "Contact support",
+				click() {
+					shell.openExternal(CONFIG.DISCORD_INVITE_URL);
+				}
+			}
+		]
+	}
+];
+
+/**
+ * Create menu
+ */
+function createMenu() {
+	const menu = Menu.buildFromTemplate(template);
+	return Menu.setApplicationMenu(menu);
+}
+
+/**
+ * About dialog box
+ */
+function showAboutDialog() {
+	dialog.showMessageBox({
+		type: "info",
+		title: `About ${CONFIG.APP_NAME}`,
+		message: `${CONFIG.APP_NAME} ${CONFIG.APP_VERSION}`,
+		detail: "All-in-one place to manage your Git repository."
+	});
+}
+
+function showUpdatesDialog() {
+	dialog.showMessageBox({
+		type: "info",
+		title: "Check for updates",
+		message: `${CONFIG.APP_NAME} updates`,
+		detail:
+			"You can stay up to day with updates by checking the releases page on Thermal GitHub repository."
+	});
+}
+
+module.exports = createMenu;


### PR DESCRIPTION
Making use of the native menu from MacOS instead of the custom [`menubar.vue`](https://github.com/gitthermal/thermal/blob/master/src/renderer/components/menubar.vue).

| Screenshot |
| --- |
| <img width="379" alt="Screenshot 2019-12-31 at 4 03 32 PM" src="https://user-images.githubusercontent.com/29014463/71618762-19e37c00-2be7-11ea-9948-7491c4bb3d6f.png"> |

**NOTE:** Custom menubar will be still be used in Windows and Linux.


